### PR TITLE
Step11/sort task

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: "DESC")
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -11,7 +11,7 @@
 
 <% @tasks.each do |task| %>
   <tr>
-    <td><%= task.title %></td>
+    <td class="task-index__title"><%= task.title %></td>
     <td><%= task.content %></td>
     <td><%= task.deadline %></td>
     <td><%= task.priority %></td>

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :task do
+    title { 'test_task_01' }
+    content { 'testtesttest' }
+    created_at { '2019-05-26 13:30:15 +0900' }
+  end
+
+  factory :second_task, class: Task do
+    title { 'test_task_02' }
+    content { 'samplesample' }
+    created_at { '2019-06-26 13:30:15 +0900' }
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -37,6 +37,8 @@ RSpec.feature "タスク管理機能", type: :feature do
 end
 
 
+
+# タスクが作成日時の降順に並んでいるかのテストについての解説
 # before:
 # b = []
 # Task.all.order(created_at: "DESC").each do |task|

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
+  background do
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
+  end
+
   scenario "タスク一覧のテスト" do
-    Task.create!(title: 'test_task_01', content: 'testtesttest')
-    Task.create!(title: 'test_task_02', content: 'samplesample')
     visit root_path
     expect(page).to have_content 'testtesttest'
     expect(page).to have_content 'samplesample'
@@ -13,7 +16,7 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit new_task_path
     fill_in 'task', with: 'testtesttest'
     fill_in 'content', with: 'samplesample'
-    click_on 'Create Task'
+    click_on '新規作成'
     expect(page).to have_content'testtesttest'
     expect(page).to have_content'samplesample'
   end
@@ -23,4 +26,30 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit task_path(@task.id)
     expect(page).to have_content 'testtesttest'
   end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    visit root_path
+    # .はclass #id
+    expect(
+      all('.task-index__title').map(&:text)
+    ).to eql Task.all.order(created_at: "DESC").map(&:title)
+  end
 end
+
+
+# before:
+# b = []
+# Task.all.order(created_at: "DESC").each do |task|
+#   b.push(task.title)
+# end
+
+# after level 1
+# b = Task.all.order(created_at: "DESC").map do |task|
+#   task.id
+# end
+
+# after level 2 do end は1行で描きたいときは{ }
+# b = Task.all.order(created_at: "DESC").map { |task| task.id }
+
+# after level 3 値を一個ずつつ取り出してやるとき(&使う時は{}は()になる)
+# b = Task.all.order(created_at: "DESC").map(&:id)


### PR DESCRIPTION
IDの順で並んでいるタスクを作成日時の降順で並び替えました。
並び替えがうまく行っていることをfeature specで書きました。